### PR TITLE
Add unlisted post status and filter to admin post list.

### DIFF
--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -164,7 +164,7 @@ class Unlist_Posts_Admin {
 
 		// Check if this post is unlisted and mark it as so if appropriate.
 		if ( in_array( $post->ID, $unlisted_posts ) ) {
-			$states[] = 'Unlisted';
+			$states[] = __( 'Unlisted', 'unlist-posts' );
 		}
 
 		return $states;
@@ -188,7 +188,7 @@ class Unlist_Posts_Admin {
 			$link_attributes = 'class="current" aria-current="page"';
 		}
 
-		$views['unlisted'] = '<a href="edit.php?post_status=unlisted&post_type=post" ' . $link_attributes . '>Unlisted <span class="count">(' . $unlisted_count . ')</span></a>';
+		$views['unlisted'] = '<a href="edit.php?post_status=unlisted&post_type=post" ' . $link_attributes . '>' . __( 'Unlisted', 'unlist-posts' ) . ' <span class="count">(' . $unlisted_count . ')</span></a>';
 
 		return $views;
 	}

--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -188,7 +188,7 @@ class Unlist_Posts_Admin {
 			$link_attributes = 'class="current" aria-current="page"';
 		}
 
-		$views['unlisted'] = '<a href="edit.php?post_status=unlisted&post_type=post" ' . $link_attributes . '>' . __( 'Unlisted', 'unlist-posts' ) . ' <span class="count">(' . $unlisted_count . ')</span></a>';
+		$views['unlisted'] = '<a href="edit.php?post_status=unlisted&post_type=post" ' . $link_attributes . '>' . __( 'Unlisted', 'unlist-posts' ) . ' <span class="count">(' . esc_html( $unlisted_count ) . ')</span></a>';
 
 		return $views;
 	}

--- a/languages/unlist-posts.pot
+++ b/languages/unlist-posts.pot
@@ -38,6 +38,10 @@ msgid ""
 "direct URL."
 msgstr ""
 
+#: class-unlist-posts-admin.php:167
+msgid "Unlisted"
+msgstr ""
+
 #. Plugin Name of the plugin/theme
 msgid "Unlist Posts & Pages"
 msgstr ""


### PR DESCRIPTION
### Description
- Adds ' — Unlisted' next to unlisted posts in the post list, like you'd see next to a draft or private post.
- Adds 'Unlisted' as a filter above the list of posts, similar to 'Mine' or 'Drafts,' et cetera.

### Screenshots
Unlisted post status added to post list item:
![image](https://user-images.githubusercontent.com/200641/95129998-c02d5680-0710-11eb-9272-22976e671b6c.png)

Unlisted post filter:
![image](https://user-images.githubusercontent.com/200641/95130022-ca4f5500-0710-11eb-8f0b-ad23253796cd.png)

### Types of changes
- Three new functions/hooks added to `class-unlist-posts-admin.php`.

### How has this been tested?
- Tested in a development environment with hidden posts.

### Checklist:
- [ ] My code is tested ***COULD NOT TEST***
- [ ] My code passes the PHPCS tests ***COULD NOT TEST***
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation
- [ ] I've included any necessary tests ***NO TESTS EXIST***
- [x] I've included developer documentation ***INLINE***
- [ ] I've added proper labels to this pull request ***NO LABELS AVAILABLE***
