### PR TITLE
Improvements to post filter

### DIFF
--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -185,6 +185,7 @@ class Unlist_Posts_Admin {
 	function add_unlisted_post_filter( $views ) {
 		// Get the list of unlisted post IDs from the options table.
 		$unlisted_posts = maybe_unserialize( get_option( 'unlist_posts', array() ) );
+		$count = false;
 
 		// Mark 'Unlisted' filter as the current filter if it is.
 		$link_attributes = '';
@@ -192,12 +193,17 @@ class Unlist_Posts_Admin {
 			$link_attributes = 'class="current" aria-current="page"';
 		}
 
-		$query = new WP_Query(
-			array(
-				'post_type' => get_post_type(),
-				'post__in'  => $unlisted_posts
-			)
-		);
+		if ( ! empty( $unlisted_posts ) ) {
+			$post_type = get_current_screen()->post_type ? get_current_screen()->post_type : get_post_types();
+			$query = new WP_Query(
+				array(
+					'post_type' => $post_type,
+					'post__in'  => $unlisted_posts
+				)
+			);
+
+			$count = isset( $query->found_posts ) ? $query->found_posts : false;
+		}
 
 		$link = add_query_arg(
 			array(
@@ -205,9 +211,7 @@ class Unlist_Posts_Admin {
 			)
 		);
 
-		$count = isset( $query->found_posts ) ? $query->found_posts : false;
-
-		if ( false !== $count ) {
+		if ( false !== $count && 0 !== $count ) {
 			$views['unlisted'] = '<a href=" '. esc_url( $link ) .' " ' . $link_attributes . '>' . __( 'Unlisted', 'unlist-posts' ) . ' <span class="count">(' . esc_html( $count ) . ')</span></a>';
 		}
 

--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -185,7 +185,6 @@ class Unlist_Posts_Admin {
 	function add_unlisted_post_filter( $views ) {
 		// Get the list of unlisted post IDs from the options table.
 		$unlisted_posts = maybe_unserialize( get_option( 'unlist_posts', array() ) );
-		$unlisted_count = count( $unlisted_posts );
 
 		// Mark 'Unlisted' filter as the current filter if it is.
 		$link_attributes = '';
@@ -193,13 +192,20 @@ class Unlist_Posts_Admin {
 			$link_attributes = 'class="current" aria-current="page"';
 		}
 
+		$query = new WP_Query(
+			array(
+				'post_type' => get_post_type(),
+				'post__in'  => $unlisted_posts
+			)
+		);
+
 		$link = add_query_arg(
 			array(
 				'post_status' => 'unlisted'
 			)
 		);
 
-		$views['unlisted'] = '<a href=" '. esc_url( $link ) .' " ' . $link_attributes . '>' . __( 'Unlisted', 'unlist-posts' ) . ' <span class="count">(' . esc_html( $unlisted_count ) . ')</span></a>';
+		$views['unlisted'] = '<a href=" '. esc_url( $link ) .' " ' . $link_attributes . '>' . __( 'Unlisted', 'unlist-posts' ) . ' <span class="count">(' . esc_html( $query->found_posts ) . ')</span></a>';
 
 		return $views;
 	}

--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -122,6 +122,11 @@ class Unlist_Posts_Admin {
 			return;
 		}
 
+		// Don't record unlist option for revisions.
+		if ( false !== wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
 		$hidden_posts = get_option( 'unlist_posts', array() );
 
 		if ( '' == $hidden_posts ) {

--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -205,7 +205,11 @@ class Unlist_Posts_Admin {
 			)
 		);
 
-		$views['unlisted'] = '<a href=" '. esc_url( $link ) .' " ' . $link_attributes . '>' . __( 'Unlisted', 'unlist-posts' ) . ' <span class="count">(' . esc_html( $query->found_posts ) . ')</span></a>';
+		$count = isset( $query->found_posts ) ? $query->found_posts : false;
+
+		if ( false !== $count ) {
+			$views['unlisted'] = '<a href=" '. esc_url( $link ) .' " ' . $link_attributes . '>' . __( 'Unlisted', 'unlist-posts' ) . ' <span class="count">(' . esc_html( $count ) . ')</span></a>';
+		}
 
 		return $views;
 	}


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Follow up to #40 and #41 

1. Don't save unlisted post status for revisions.
2. Get the count of posts from the current post type on any particular admin screen.
3. Hide the post status filter when the count of posts is 0

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
